### PR TITLE
chore(update patterns): Remove classNames

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,29 +1,10 @@
-import React from 'react';
-import styled from 'styled-components';
+import Circular from './Circular';
+import Image from './Image';
 
-const AvatarComponent = props => (
-  <div className={`${props.className} smc-avatar`}>
-    {props.src ? (
-      <img src={props.src} className="smc-avatar-img" />
-    ) : props.children}
-  </div>
-);
-
-export const Avatar = styled(AvatarComponent)`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: ${props => props.size || 40}px;
-  height: ${props => props.size || 40}px;
-  background: #bdbdbd;
-  border-radius: 50%;
-  overflow: hidden;
-
-  & .smc-avatar-img {
-    max-width: 100%;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
+export const Avatar = Circular.extend.attrs({
+  children: props => (props.src ? <Image src={props.src} /> : props.children),
+})`
+  // This is just here because we have to have some sort of styles applied at this level.
+  text-align: left;
 `;
+

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,28 +1,6 @@
-import React, { PureComponent } from 'react';
 import styled, { css } from 'styled-components';
 import elevation, { elevationTransition } from '../mixins/elevation';
 import ripple from '../mixins/ripple';
-
-class ButtonComponent extends PureComponent {
-  handleOnClick = (e) => {
-    this.props.onClick && this.props.onClick(e);
-  }
-
-  acceptableProps = {
-    onClick: this.handleOnClick,
-  };
-
-  render() {
-    return (
-      <button
-        className={`${this.props.className} smc-button`}
-        {...this.acceptableProps}
-      >
-        {this.props.children}
-      </button>
-    );
-  }
-}
 
 const primary = css`
   color: ${props => props.theme.primary};
@@ -58,7 +36,9 @@ const raised = css`
   `}
 `;
 
-const Button = styled(ButtonComponent)`
+const Button = styled.button.attrs({
+  'data-smc': 'Button',
+})`
   color: black;
   display: inline-block;
   position: relative;
@@ -69,9 +49,9 @@ const Button = styled(ButtonComponent)`
   border-radius: 2px;
   outline: none;
   background: transparent;
-  font-size: 14px; // Override font to specifically be px as spec defined pt
+  font-size: 14px;
   font-weight: 500;
-  line-height: 36px; // Override line-height so text aligns centered
+  line-height: 36px;
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;

--- a/src/components/Circular.js
+++ b/src/components/Circular.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const Circular = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${props => props.size || 40}px;
+  height: ${props => props.size || 40}px;
+  background: #bdbdbd;
+  border-radius: 50%;
+  overflow: hidden;
+`;

--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -1,20 +1,19 @@
-import React from 'react';
 import styled from 'styled-components';
 
-const DividerComponent = ({ className }) => <hr className={`${className} smc-divider`} />;
-
-const determineLeftMargin = ({ inset }) => {
-  if (!inset) return '0px';
-  return typeof inset === 'string' ? inset : '16px';
-};
-const Divider = styled(DividerComponent)`
+export const Divider = styled.hr.attrs({
+  'data-smc': 'Divider',
+  marginLeft: ({ inset }) => {
+    let realInset = inset;
+    if (typeof realInset === 'number') realInset = `${inset}px`;
+    if (!realInset) return '0px';
+    return typeof realInset === 'string' ? realInset : '16px';
+  },
+})`
   border: none;
   background-color: rgba(0, 0, 0, .12);
   height: 1px;
   margin-top: 0px;
   margin-bottom: 0px;
   margin-right: 0px;
-  margin-left: ${determineLeftMargin};
+  margin-left: ${props => props.marginLeft};
 `;
-
-export default Divider;

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import { Avatar } from './Avatar';
+import Circular from './Circular';
+
+export const Image = styled.img`
+  width: auto;
+  ${Avatar} &, ${Circular} & {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Avatar } from '../Avatar';
-import Divider from '../Divider';
+import { Divider } from '../Divider';
 
 const ListItemComponent = ({ className, children, leftAvatar, avatarSize, withDivider }) => (
   <li className={className}>

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ export { default as Button } from './components/Button';
 export * from './components/Card';
 export { default as Chip } from './components/Chip';
 export * from './components/Dialog';
-export { default as Divider } from './components/Divider';
+export { Divider } from './components/Divider';
 export { default as Drawer } from './components/Drawer';
 export * from './components/GridList';
 export * from './components/List';


### PR DESCRIPTION
Goal: Remove the need to create our own components simply to attach a
class name, or other identifiable attribute.

Secondary Goal: Remove classnames, which can cause styling issues, and
instead use data-smc attribute to identify the component name. Where
necessary we should use the component itself in interpolation to
actually style sub components.

This just removes the custom button component. Wrapping a component in
'styled' removes the automatic whitelisting of props that react does.
This removes the need to declare an intermediate click action and white
list the props on the button.

### EDIT:
This is an evolving PR that will contain a lot of API updates. Each API update will be detailed here:

#### Avatar
I decided to decompose this component into one that uses other basic building block components (Circular and Image) to compose itself. This allows for using the reverse selector pattern to keep styles at the level that they should be. It also allows the end user to import Circular and Image from the library and use them for styles. Suggested API:
```js
import { Avatar, Image } from 'styled-material-components';

const CustomAvatar = Avatar.extend`
  width: 400px;
  & ${Image} {
    width: 400px;
  }
`;
```
