### PR TITLE
Sidebar Spec Fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@
  calebjanderson <caleb.anderson130@gmail.com>
  ceciliamvrie <ceciliamvrie@gmail.com>
  haileybee1231 <haileybee1231@gmail.com>
+ bennett staley <me@bennettstaley.com>

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,4 +1,4 @@
-import Circular from './Circular';
+import { Circular } from './Circular';
 import Image from './Image';
 
 export const Avatar = Circular.extend.attrs({

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -5,12 +5,7 @@ import elevation from '../mixins/elevation';
 import { Portal } from '../components/Portal';
 
 const drawerSizing = css`
-  width: calc(100% - 56px);
-  max-width: 280px;
-  @media (min-width: 600px) {
-    width: calc(100% - 64px);
-    max-width: 320px;
-  }
+  width: 240px;
 `;
 
 // eslint-disable-next-line no-unused-expressions
@@ -21,7 +16,7 @@ injectGlobal`
         &:after {
           content: "";
           ${drawerSizing}
-          display: inline-flex;
+          display: inline-table;
           box-sizing: border-box;
         }
       }
@@ -29,7 +24,7 @@ injectGlobal`
         &:before {
           content: "";
           ${drawerSizing}
-          display: inline-flex;
+          display: inline-table;
           box-sizing: border-box;
         }
       }

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -37,7 +37,7 @@ export class Portal extends Component {
   }
 
   componentWillUnmount() {
-    smcPortal.removeChild(this.el);
+    smcPortal && smcPortal.removeChild(this.el);
   }
 
   render() {


### PR DESCRIPTION
Adjusts the sidebar spec to reflect the spec defined within material.

Changes:
Width is now fixed to 240px, as spec dictates. Also changes the display to inline-table for the Before/After left and right shifts, meaning the (persistent) sidebar will always take up the space it requires, as spec dictates.

https://docs-hftsbpxxmj.now.sh !

Fixes Issue #147