### PR TITLE
refactored drawer styles to match spec

### DIFF
--- a/pages/appbar.js
+++ b/pages/appbar.js
@@ -36,7 +36,7 @@ export default class AppbarPage extends Component {
               attachment="right"
               open={this.state.persistentRight}
               handleRequestClose={this.togglePersistentRight}>
-              <Appbar title='I am in this drawer!' />
+              <Appbar drawer title='I am in this drawer!' />
               <p>{'hello!'}</p>
             </Drawer>
             <Button

--- a/src/components/Appbar.js
+++ b/src/components/Appbar.js
@@ -10,7 +10,7 @@ const NavIcon = styled.div`
   margin: 12px;
 `;
 
-const TitleComponent = ({ className, children }) => (
+const TitleComponent = ({ className, children, drawer }) => (
   <h1 className={`${className} smc-appbar-title`}>
     {children}
   </h1>
@@ -18,7 +18,12 @@ const TitleComponent = ({ className, children }) => (
 
 const Title = styled(TitleComponent)`
   margin: 0 12px;
-   ${typography('title')}
+  ${typography('title')}
+  ${({ drawer }) => drawer !== undefined && `
+    font-size: 17px;
+    position: absolute;
+    right: 3px;
+  `}
 `;
 
 class AppbarComponent extends PureComponent {
@@ -28,7 +33,7 @@ class AppbarComponent extends PureComponent {
         className={`${this.props.className} smc-appbar-container`}
       >
         <NavIcon />
-        <Title>{`${this.props.title}`}</Title>
+        <Title drawer={this.props.drawer} >{`${this.props.title}`}</Title>
       </div>
     );
   }
@@ -45,6 +50,11 @@ const Appbar = styled(AppbarComponent)`
   height: 64px;
   position: sticky;
   color: #fff;
+  ${({ drawer }) => drawer && `
+    align-items: flex-end;
+    padding: 12px;
+    height: 155px;
+  `};
 `;
 
 export default Appbar;

--- a/src/components/Appbar.js
+++ b/src/components/Appbar.js
@@ -10,7 +10,7 @@ const NavIcon = styled.div`
   margin: 12px;
 `;
 
-const TitleComponent = ({ className, children, drawer }) => (
+const TitleComponent = ({ className, children }) => (
   <h1 className={`${className} smc-appbar-title`}>
     {children}
   </h1>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -5,7 +5,7 @@ import elevation from '../mixins/elevation';
 import { Portal } from '../components/Portal';
 
 const drawerSizing = css`
-  width: 240px;
+  width: 320px;
 `;
 
 // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
I refactored the styles of the AppBar Drawer component to further match the look of the spec. 
To accomodate for there being two different types of AppBars, I passed a drawer prop through to specify if the AppBar should be a Drawer or not. 

Modified: 
* AppBar 
* Drawer 

Link => https://docs-frjntmeopo.now.sh!