### PR TITLE
fix/chip: export chip as styled component

### DIFF
--- a/pages/chips.js
+++ b/pages/chips.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from 'react';
-import styled from 'styled-components';
 import MaterialThemeProvider from '../src/theme/ThemeProvider';
 import Chip, { Avatar, Label, DeleteIcon } from '../src/components/Chip';
 
@@ -7,7 +6,7 @@ const demo = (area) => {
   alert(`You clicked on the ${area}`);
 };
 
-const CustomChip = styled(Chip)`
+const CustomChip = Chip.extend`
   ${Avatar} {
     background-color: skyblue;
   }

--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -121,5 +121,5 @@ class Chip extends PureComponent {
   }
 }
 
-export default Chip;
+export default styled(Chip)``;
 export { ChipContainer, Label, Avatar, DeleteIcon };


### PR DESCRIPTION
Previously Chip had been written with all of its subcomponents as styled components, but the default export was not. This PR corrects that so the Chip component will have S-C methods like `extend` available to it.