### PR TITLE
Implement dropdown menu

### DIFF
--- a/pages/text-fields.js
+++ b/pages/text-fields.js
@@ -38,7 +38,7 @@ class TextFieldPage extends PureComponent {
           <TextFieldWithBottomMargin defaultValue={'Default Value'} />
           <TextFieldWithBottomMargin
             floatingLabelText={'floating label'}
-          />
+          /> 
           <TextFieldWithBottomMargin
             hintText={'with hint text'}
             floatingLabelText={'floating label'}
@@ -114,6 +114,28 @@ class TextFieldPage extends PureComponent {
             onReset={() => this.setState({ shouldReset: false })}
           />
           <Button onClick={() => this.setState({ shouldReset: true })}>Reset</Button>
+          <h2>Dropdown Menu</h2>
+          <TextFieldWithBottomMargin
+              floatingLabelText="Dropdown Menu"
+              options={["option1", "option2"]}
+          />
+          <h4>No Selected Default Option</h4>
+          <TextFieldWithBottomMargin
+              floatingLabelText="Dropdown Menu"
+              options={["option1", "option2"]}
+              defaultOption={"select an option"}
+          />
+          <h4>Selected Default Option</h4>
+          <TextFieldWithBottomMargin
+              floatingLabelText="Dropdown Menu"
+              options={["option0", "option1", "option2"]}
+              defaultOption={"option2"}
+          />
+          <h4>Invalid Options Passed In</h4>
+          <TextFieldWithBottomMargin
+              floatingLabelText="Dropdown Menu"
+              options={"invalid option"}
+          />
         </div>
       </MaterialThemeProvider>
     );

--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -1,0 +1,119 @@
+import styled from 'styled-components';
+import React, { Component, Fragment } from 'react';
+import MenuItem from './Menu/MenuItem';
+import Menu from './Menu/Menu';
+import { ArrowDropDown } from './../icons/icons';
+
+const Dropdown = styled.select`
+  border-color: transparent;
+  background-color: transparent;
+  color: black;
+  width: 100%;
+  position: absolute;
+  z-index: 1;
+  font-size: 17px;
+  -webkit-appearance: button; /* hide default arrow in chrome OSX */
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const HiddenOption = styled.option`
+  display: none;
+`;
+
+const Symbol = styled(ArrowDropDown)`
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  right: 0;
+  bottom: 5px;
+  fill: #726969;
+`;
+
+
+export default class DropdownMenu extends Component {
+  state = {
+    isOpen: false,
+    options: this.props.options || [],
+    selected: this.props.defaultOption || 'select one',
+    isChrome: undefined,
+  }
+  
+  /* eslint-disable react/no-did-mount-set-state */
+  /*
+   * Because Next.js executes its code server-side first,
+   * using navigator and window will result to a reference error
+   * outside of the componentDidMount method. Therefore, setting
+   * the state inside of here is the only way to keep track of what
+   * browser is being used on the client side.
+   *
+   * https://github.com/zeit/next.js/wiki/FAQ
+   */
+
+  componentDidMount() {
+    if (navigator) {
+      const isChrome = Boolean(/Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor));
+      this.setState({ isChrome });
+    }
+  }
+  /* eslint-enable react/no-did-mount-set-state */
+   
+  onSelectMenuItem = (option): void => {
+    this.setState({ selected: option });
+  }
+
+  toggleSelect = (e): boolean => {
+    e.preventDefault();
+    this.setState({ isOpen: !this.state.isOpen });
+  }
+
+  render() {
+    const { options, isOpen, selected, isChrome } = this.state;
+    return (
+      <div onClick={this.toggleSelect}>
+        {isChrome === false && (
+          <Dropdown
+            defaultValue={selected}
+          >
+            {options.map(option => (
+              <option key={option}>
+                {option}
+              </option>
+            ))}
+          </Dropdown>
+        )}
+        {isChrome === true && (
+          <Fragment>
+            <Dropdown
+              value={selected}
+              hidden={isOpen}
+            >
+              {options.map(option => (
+                <HiddenOption key={option}>
+                  {option}
+                </HiddenOption>
+              ))}
+            </Dropdown>
+            <Menu
+              aria-hidden="true"
+              value={selected}
+              open={isOpen}
+            >
+              {options.map(option => (
+                <MenuItem
+                  key={option}
+                  onClick={() => this.onSelectMenuItem(option)}
+                >
+                  {option}
+                </MenuItem>
+              ))}
+            </Menu>
+          </Fragment>
+        )}
+        <Symbol />
+      </div>
+    );
+  }
+}

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-confusing-arrow */
 import styled, { css } from 'styled-components';
 import React, { PureComponent } from 'react';
+import DropdownMenu from './DropdownMenu';
 
 class TextFieldComponent extends PureComponent {
   state = {
@@ -45,6 +46,11 @@ class TextFieldComponent extends PureComponent {
   };
 
   render() {
+    const hasValidOptions = this.props.options && (
+      Array.isArray(this.props.options) &&
+      this.props.options.length > 0
+    );
+
     const hasError = Boolean(this.state.error || this.props.error || this.props.errorText);
     return (
       <div className={`${this.props.className} smc-text-field-container`}>
@@ -58,7 +64,12 @@ class TextFieldComponent extends PureComponent {
           floatingLabelStyle={
             hasError ? this.props.floatingLabelErrorStyle : this.props.floatingLabelStyle
           }
-          floating={this.state.focus || this.props.hintText || this.state.text.length}
+          floating={this.state.focus ||
+            this.props.hintText ||
+            this.props.options ||
+            this.props.defaultOption ||
+            this.state.text.length
+          }
         >
           {this.props.floatingLabelText || ''}
           {this.props.required ? '*' : ''}
@@ -67,15 +78,23 @@ class TextFieldComponent extends PureComponent {
             show={this.props.required}
             requiredStarStyle={this.props.requiredStarStyle} /> */}
         </FloatingLabel>
-        <HintText
-          className={'smc-text-field-hint-text'}
-          hintTextStyle={this.props.hintTextStyle}
-          hasPrefix={this.props.prefix}
-          error={hasError}
-          show={!this.props.defaultValue && !this.state.text.length && !this.props.value}
-        >
-          {this.props.hintText}
-        </HintText>
+        {hasValidOptions && (
+          <DropdownMenu
+            defaultOption={this.props.defaultOption}
+            options={this.props.options}
+          />
+        )}
+        {!this.props.options && (
+          <HintText
+            className={'smc-text-field-hint-text'}
+            hintTextStyle={this.props.hintTextStyle}
+            hasPrefix={this.props.prefix}
+            error={hasError}
+            show={!this.props.defaultValue && !this.state.text.length && !this.props.value}
+          >
+            {this.props.hintText}
+          </HintText>
+        )}
         {this.props.helperText && (
           <HelperText
             className={'smc-text-field-helper-text'}
@@ -85,6 +104,15 @@ class TextFieldComponent extends PureComponent {
             {this.props.helperText}
           </HelperText>
         )}
+        {(this.props.options && !hasValidOptions) && (
+          <ErrorText
+            show={!hasError}
+            className={'smc-text-field-error-text'}
+            errorTextStyle={this.props.errorTextStyle}
+          >
+            Must have an array of at least one option passed in
+          </ErrorText>
+        )}
         <ErrorText
           show={hasError}
           className={'smc-text-field-error-text'}
@@ -93,7 +121,7 @@ class TextFieldComponent extends PureComponent {
           {this.props.errorText}
         </ErrorText>
         <UnderlineFocus
-          disabled={this.props.focusDisabled}
+          disabled={this.props.options || this.props.focusDisabled}
           className={'smc-text-field-underline-focus'}
           underlineFocusStyle={this.props.underlineFocusStyle}
           focus={this.state.focus}
@@ -122,7 +150,7 @@ class TextFieldComponent extends PureComponent {
               hasPrefix={!!this.props.prefix}
               hasSuffix={!!this.props.suffix}
               inputStyle={this.props.inputStyle}
-              disabled={this.props.disabled}
+              disabled={this.props.options || this.props.disabled}
               autoFocus={this.props.autoFocus}
               value={this.props.value || this.state.text}
               onChange={this.onChange}
@@ -297,6 +325,9 @@ const TextField = styled(TextFieldComponent)`
   font-family: lato, sans-serif;
   border-bottom: 0.5px ${props => (props.disabled ? 'dotted' : 'solid')};
   border-bottom-color: ${props => (props.error ? error : hintTextColor)};
+  ${props => props.options && `
+    border-bottom-color: #726969;
+  `}
 `;
 
 export default TextField;


### PR DESCRIPTION
#Implemented a new textfield to be used in the property details page. 
Added support for multiple browsers, as well as a11y. 

link => https://docs-wnyapgsmik.now.sh
spec link => https://material.io/guidelines/components/text-fields.html#text-fields-layout