### PR TITLE
feat(Checkbox): improve handling of indeterminate

### DIFF
--- a/pages/checkboxes.js
+++ b/pages/checkboxes.js
@@ -8,7 +8,7 @@ import defaultTheme from '../src/theme/defaultTheme';
 const StyledCheckbox = Checkbox.extend`
   ${Box} {
     background-color: transparent;
-    border-color: skyblue
+    border-color: skyblue;
   }
   ${CheckMark} {
     stroke: hotpink;
@@ -40,7 +40,7 @@ class CheckboxesPage extends PureComponent {
             <label htmlFor="checkbox1">Primary</label>
           </ListItem>
           <ListItem>
-            <Checkbox defaultChecked id="checkbox3" />
+            <Checkbox default="checked" id="checkbox3" />
             <label htmlFor="checkbox3">Defaults to Checked</label>
           </ListItem>
           <ListItem>
@@ -56,7 +56,7 @@ class CheckboxesPage extends PureComponent {
             <label htmlFor="checkbox6">Controlled Checkbox</label>
           </ListItem>
           <ListItem>
-            <Checkbox indeterminate id="checkbox7" />
+            <Checkbox default="indeterminate" id="checkbox7" />
             <label htmlFor="checkbox7">Indeterminate Checkbox</label>
           </ListItem>
           <ListItem>

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 class Checkbox extends PureComponent {
   state = {
-    checked: this.props.checked || this.props.defaultChecked || false,
-    indeterminate: this.props.indeterminate || false,
+    checked: this.props.checked || this.props.default === 'checked' || false,
+    indeterminate: this.props.default === 'indeterminate' || false,
   };
 
   handleInputChange = (e) => {
@@ -17,24 +17,23 @@ class Checkbox extends PureComponent {
   };
 
   render() {
-    const { primary, disabled, checked: checkedProp, value, id, className } = this.props;
-    const { indeterminate } = this.state;
+    const {
+      primary,
+      disabled,
+      checked: checkedProp,
+      indeterminate: indeterminateProp,
+      value,
+      id,
+      className,
+    } = this.props;
     // determine if checkbox is controlled or uncontrolled
     const checked = checkedProp !== undefined ? checkedProp : this.state.checked;
+    const indeterminate =
+      indeterminateProp !== undefined ? indeterminateProp : this.state.indeterminate;
 
     return (
-      <Wrapper
-        className={className}
-        primary={primary}
-        disabled={disabled}
-        checked={checked}
-      >
-        <Box
-          primary={primary}
-          checked={checked}
-          disabled={disabled}
-          indeterminate={indeterminate}
-        >
+      <Wrapper className={className} primary={primary} disabled={disabled} checked={checked}>
+        <Box primary={primary} checked={checked} disabled={disabled} indeterminate={indeterminate}>
           {indeterminate && <IndeterminateMark />}
           {checked && !indeterminate && <CheckMark />}
         </Box>


### PR DESCRIPTION
API change: `defaultChecked` prop removed and replaced with a `default` prop which can accept 'checked' or 'indeterminate'. 

Should allow forms that are controlling checkboxes to reset them back to an indeterminate state. 