### PR TITLE
refactor(Table): Remove elevation

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -8,7 +8,6 @@ import Title from './Title';
 import Header from './Header';
 import Footer from './Footer';
 import naturalSort from './naturalSort';
-import elevation from '../../mixins/elevation';
 import Checkbox from '../Checkbox';
 import { ArrowUpwardIcon } from '../../icons/icons';
 
@@ -307,7 +306,6 @@ class Table extends PureComponent {
 
 export default styled(Table) `
   ${props => (props.fullWidth ? 'width: 100%' : '')};
-  ${elevation(3)};
   display: inline-block;
   overflow: hidden;
   background-color: #fff;


### PR DESCRIPTION
I feel as though we should remove elevation from being on the tables. According to spec, it seems as though the table itself doesn't have elevation on it, but rather inserting the tables into cards.

Right now we have tables within cards, and it now has double elevation.

Here is the spec, with the section I'm referring to being (Tables within cards): https://material.io/guidelines/components/data-tables.html#data-tables-tables-within-cards

Now Link: https://docs-sndqbfdqsj.now.sh