### PR TITLE
fix(Snackbar): Remove from DOM if closed

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -76,10 +76,10 @@ class SnackbarComponent extends PureComponent {
 }
 
 const Snackbar = styled(SnackbarComponent)`
+  display: ${props => (props.open && !props.animateOut ? 'flex' : 'none')};
   position: fixed;
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
   height: 48px;
   min-width: 288px;
   max-width: 568px;


### PR DESCRIPTION
This is setting the Snackbar to display none if it is not yet opened. In the Merlin repo it's easy to see the error / recreate it, but in SMC it's hard to reproduce the same effect.

I'm hoping this could potentially resolve what is happening in this issue #193.
