### PR TITLE
fix(Dialog): Fix overlay to correct position

### DIFF
--- a/src/components/Portal/Overlay.js
+++ b/src/components/Portal/Overlay.js
@@ -12,7 +12,7 @@ export const BaseOverlay = props => (
 
 export const Overlay = styled(BaseOverlay)`
   background: rgba(0, 0, 0, .6);
-  position: absolute;
+  position: fixed;
   left: 0;
   right: 0;
   bottom: 0;


### PR DESCRIPTION
Fixes Portal Overlay to `position:fixed`. Currently if the page has
scrolled and a dialog is opened, the dialog is only shown at the top of the page.
This PR allows the dialog to scroll and take up 100% of the current
view.

https://docs-cbziuwrhqb.now.sh/dialog/