### PR TITLE
fix(Divider): fix `marginLeft` console warning

### DIFF
--- a/src/components/Divider.js
+++ b/src/components/Divider.js
@@ -2,18 +2,17 @@ import styled from 'styled-components';
 
 export const Divider = styled.hr.attrs({
   'data-smc': 'Divider',
-  marginLeft: ({ inset }) => {
-    let realInset = inset;
-    if (typeof realInset === 'number') realInset = `${inset}px`;
-    if (!realInset) return '0px';
-    return typeof realInset === 'string' ? realInset : '16px';
-  },
 })`
   border: none;
-  background-color: rgba(0, 0, 0, .12);
+  background-color: rgba(0, 0, 0, 0.12);
   height: 1px;
   margin-top: 0px;
   margin-bottom: 0px;
   margin-right: 0px;
-  margin-left: ${props => props.marginLeft};
-`;
+  margin-left: ${({ inset }) => {
+    let realInset = inset;
+    if (typeof realInset === 'number') realInset = `${inset}px`;
+    if (!realInset) return '0px';
+    return typeof realInset === 'string' ? realInset : '16px';
+  }};
+  `;


### PR DESCRIPTION
Fixes #203 

This PR fixes the console warnings that were being thrown whenever Divider was in use by removing the marginLeft attribute from the `<hr>` and moving the logic into css.