### PR TITLE
feat(screensizecontext): pass platform to context

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.0",
+    "platform": "^1.3.5",
     "react": "^16.0.0",
     "react-tunnels": "^1.0.2",
     "recompose": "^0.26.0",

--- a/src/contexts/ScreenSizeContext.js
+++ b/src/contexts/ScreenSizeContext.js
@@ -1,6 +1,7 @@
 /**
  * @file ScreenSizeContext
  * @author Brad Decker <bhdecker84@gmail.com|brad@merlinlabs.com>
+ * @author Ari Frankel <ari.l.frankel@gmail.com|ari@merlinlabs.com>
  * @description Defines a context that will allow all children to
  * access the current screenSize. This is implmented using respondable.
  * All breakpoints are adjustable by the end user.
@@ -9,6 +10,7 @@ import React, { Component } from 'react';
 import createReactContext from 'create-react-context';
 import { withTheme } from 'styled-components';
 import respondable from 'respondable';
+import platform from 'platform';
 
 /**
  * Context
@@ -34,9 +36,22 @@ export const ScreenSizeConsumer = Context.Consumer;
 class ScreenSizeContextBase extends Component {
   state = {
     screenSize: 'server',
+    platformData: {},
   };
 
   componentDidMount() {
+    // Get platform data using Platform
+    // It is necessary to capture the platform data on the client.
+    // Platform relies on window.navigator.
+    // eslint-disable-next-line
+    this.setState({
+      platformData: {
+        product: platform.product,
+        osFamily: platform.os ? platform.os.family : null,
+        majorVersion: platform.version ? parseInt(platform.version.split('.')[0], 10) : -1,
+        majorOsVersion: platform.os && platform.os.version ? parseInt(platform.os.version.split('.')[0], 10) : -1,
+      },
+    });
     // Initialize Respondable
     // first prop is a map in the form of [mediaQuery]: 'string'
     // If the mediaQuery matches, 'string' will be returned as active.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4602,6 +4602,10 @@ pkg-up@2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+platform@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"


### PR DESCRIPTION
This adds platform.js to check the user's platform and pass that
information along with the screen size context.

My thinking for including this in screen size context is that the consumers of screen size context are likely to be the ones that care about platform.