### PR TITLE
fix(Dropdown): update styles

### DIFF
--- a/src/components/DropdownMenu.js
+++ b/src/components/DropdownMenu.js
@@ -12,6 +12,7 @@ const Dropdown = styled.select`
   position: absolute;
   z-index: 1;
   font-size: 17px;
+  cursor: pointer;
   -webkit-appearance: button; /* hide default arrow in chrome OSX */
 
   &:focus {
@@ -60,6 +61,15 @@ export default class DropdownMenu extends Component {
       this.setState({ isChrome });
     }
   }
+
+  handleClose = () => {
+    this.setState({ isOpen: false });
+  };
+
+  handleOpen = () => {
+    this.setState({ isOpen: true });
+  };
+
   /* eslint-enable react/no-did-mount-set-state */
 
   onSelectMenuItem = (option): void => {
@@ -74,7 +84,7 @@ export default class DropdownMenu extends Component {
   render() {
     const { options, isOpen, selected, isChrome } = this.state;
     return (
-      <div onClick={this.toggleSelect}>
+      <div onClick={this.toggleSelect} onFocus={this.handleOpen} tabIndex="0">
         {isChrome === false && (
           <Dropdown
             defaultValue={selected}
@@ -103,6 +113,7 @@ export default class DropdownMenu extends Component {
               aria-hidden="true"
               value={selected}
               open={isOpen}
+              onClose={this.handleClose}
             >
               {options.map(option => (
                 <MenuItem

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -15,7 +15,7 @@ class MenuComponent extends Component {
 
   handleClick = (event) => {
     if (this.menu.contains(event.target)) return;
-    this.props.onClose && this.props.onClose();
+    this.props.onClose && this.props.onClose(event);
   }
 
   render() {

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -9,7 +9,7 @@ import Header from './Header';
 import Footer from './Footer';
 import naturalSort from './naturalSort';
 import Search from './Search';
-import Checkbox from '../Checkbox';
+import { Checkbox } from '../Checkbox';
 import { ArrowUpwardIcon } from '../../icons/icons';
 
 /*

--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -343,9 +343,6 @@ const TextField = styled(TextFieldComponent) `
   font-family: lato, sans-serif;
   border-bottom: 0.5px ${props => (props.disabled ? 'dotted' : 'solid')};
   border-bottom-color: ${props => (props.error ? error : hintTextColor)};
-  ${props => props.options && `
-    border-bottom-color: #726969;
-  `}
 `;
 
 export default TextField;


### PR DESCRIPTION
This PR

- fixes underline color to match theme styles
- adds pointer on hover
- adds request close when click is registered outside of an open menu
- allows dropdown menu to be tabbed into with keyboard

Resolve #199, Resolve #197, Resolve #196, Resolve #179 

Demo: https://docs-tcqmhzveck.now.sh/text-fields/