### PR TITLE
fix(Menu): Add anchor element to attach to

### DIFF
--- a/pages/menus.js
+++ b/pages/menus.js
@@ -9,10 +9,11 @@ class MenusPage extends Component {
   state = {
     open: false,
     value: '',
+    anchorEl: null,
   };
 
-  handleClick = () => {
-    this.setState({ open: !this.state.open });
+  handleClick = (event) => {
+    this.setState({ open: !this.state.open, anchorEl: event.currentTarget });
   };
 
   handleSelect = (selectedItem) => {
@@ -25,6 +26,8 @@ class MenusPage extends Component {
   };
 
   render() {
+    const { anchorEl } = this.state;
+
     const menuItems = [
       { text: 'Un', onClick: () => this.handleSelect() },
       { text: 'Deux', onClick: () => this.handleSelect() },
@@ -44,18 +47,17 @@ class MenusPage extends Component {
           <p>This component is accessible (navigable by clicks or keyboard events)
             and has an ARIA role defined as menu for screenreaders </p>
           <p>Each Option can receive a handleSelect prop that accepts a callback</p>
-          <div style={{ position: 'relative', display: 'flex', width: '800px' }}>
-            <Button raised onClick={this.handleClick} style={{ marginRight: '15px' }}>Click me</Button>
-            <Menu
-              open={this.state.open}
-              value={this.state.value}
-              onClose={() => this.handleClose()}>
-              <MenuItem onClick={() => this.handleSelect('Ron')}>Ron</MenuItem>
-              <MenuItem onClick={() => this.handleSelect('Harry')}>Harry</MenuItem>
-              <MenuItem onClick={() => this.handleSelect('Hermione')}>Hermione</MenuItem>
-            </Menu>
-            <h3>You selected: <span style={{ color: 'tomato' }}>{this.state.value}</span></h3>
-          </div>
+          <Button raised onClick={this.handleClick} style={{ marginRight: '15px', float: 'right' }}>Click me</Button>
+          <Menu
+            open={this.state.open}
+            anchorEl={anchorEl}
+            value={this.state.value}
+            onClose={() => this.handleClose()}>
+            <MenuItem onClick={() => this.handleSelect('Ron')}>Ron</MenuItem>
+            <MenuItem onClick={() => this.handleSelect('Harry')}>Harry</MenuItem>
+            <MenuItem onClick={() => this.handleSelect('Hermione')}>Hermione</MenuItem>
+          </Menu>
+          <h3>You selected: <span style={{ color: 'tomato' }}>{this.state.value}</span></h3>
         </div>
       </ThemeProvider>
     );

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import elevation from '../../mixins/elevation';
 import MenuList from './MenuList';
 import MenuItem from './MenuItem';
@@ -8,7 +8,7 @@ class MenuComponent extends Component {
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClick, false);
   }
-  
+
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleClick, false);
   }
@@ -41,9 +41,15 @@ class MenuComponent extends Component {
   }
 }
 
+const positionStyles = css`
+  top: ${props => props.anchorEl && props.anchorEl.getBoundingClientRect().top}px;
+  left: ${props => props.anchorEl && props.anchorEl.getBoundingClientRect().left}px;
+`;
+
 const Menu = styled(MenuComponent)`
   padding: 0;
   position: absolute;
+  ${positionStyles}
   box-sizing: border-box;
   border-radius: 2px;
   overflow: hidden;


### PR DESCRIPTION
This allows us to attach an anchor element to the menu to know the position at which the menu opens up to.

This doesn't add in the fix to open it in different directions based on where it is at in the window quite yet.

Would be curious to get thoughts on this!

Now link: https://docs-exezjdowac.now.sh