### PR TITLE
feat(contexts): use HOCs

### DIFF
--- a/src/components/FlexGrid/Column.js
+++ b/src/components/FlexGrid/Column.js
@@ -1,6 +1,7 @@
 /**
  * @file Column
  * @author Brad Decker <bhdecker84@gmail.com|brad@merlinlabs.com>
+ * @author Ari Frankel <ari.l.frankel@gmail.com|ari@merlinlabs.com>
  * @description Defines a flex grid column that responds to the size
  * of the screen to grow, shrink, reorder as described by the end
  * user via size props.
@@ -209,7 +210,7 @@ const enhancer = compose(
 );
 
 const ColumnComponent = enhancer(
-  ({ className, children, ...props }, { screenSizeState, rowState }) => (
+  ({ className, children, screenSizeState, rowState, ...props }) => (
     <SizedColumn
       {...props}
       data-smc="Column"

--- a/src/components/FlexGrid/Row.js
+++ b/src/components/FlexGrid/Row.js
@@ -1,10 +1,11 @@
 /**
  * @file Row
  * @author Brad Decker <bhdecker84@gmail.com|brad@merlinlabs.com>
+ * @author Ari Frankel <ari.l.frankel@gmail.com|ari@merlinlabs.com>
  * @description Defines a flex grid row that has props defined for
  * easily setting some common flex styles.
  */
-import React, { Component } from 'react';
+import React, { Component, ComponentType } from 'react';
 import styled from 'styled-components';
 import createReactContext from 'create-react-context';
 import { rowMixin } from '../../mixins/flex';
@@ -86,9 +87,12 @@ export const Row = styled(RowComponent)`
   ${props => rowMixin(props)}
 `;
 
-export const withRowState = fn => (props, context = {}) => (
+export const withRowState = (ComposedComponent: ComponentType<*>) => props => (
   <RowConsumer>
-    {rowState => fn(props, { ...context, rowState })}
+    {rowState => (
+      <ComposedComponent {...props} rowState={rowState}>
+        {props.children}
+      </ComposedComponent>
+    )}
   </RowConsumer>
 );
-

--- a/src/contexts/ScreenSizeContext.js
+++ b/src/contexts/ScreenSizeContext.js
@@ -6,11 +6,26 @@
  * access the current screenSize. This is implmented using respondable.
  * All breakpoints are adjustable by the end user.
  */
-import React, { Component } from 'react';
+import React, { ComponentType, Component } from 'react';
 import createReactContext from 'create-react-context';
 import { withTheme } from 'styled-components';
 import respondable from 'respondable';
 import platform from 'platform';
+
+/*
+ * Utilities for screen size. May want to move this in to a lib file soon
+ * as it likely grows soon
+*/
+const screenSizes = ['xs', 'sm', 'md', 'lg', 'xl', 'server'];
+export type screenSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'server';
+
+export const greaterThanOrEqual = (refSize: screenSize) => (size: screenSize) =>
+  screenSizes.indexOf(size) >= screenSizes.indexOf(refSize);
+
+export const lessThanOrEqual = (refSize: screenSize) => (size: screenSize) =>
+  screenSizes.indexOf(size) <= screenSizes.indexOf(refSize);
+
+export const isDesktop = greaterThanOrEqual('lg');
 
 /**
  * Context
@@ -140,8 +155,17 @@ class ScreenSizeContextBase extends Component {
 // withTheme gives us access to the theme without it being a Styled Component
 export const ScreenSizeContext = withTheme(ScreenSizeContextBase);
 
-export const withScreenSize = fn => (props, context = {}) => (
+// This HOC will pass along screenSizeState as well as the isDesktop method
+export const withScreenSize = (ComposedComponent: ComponentType<*>) => props => (
   <ScreenSizeConsumer>
-    {screenSizeState => fn(props, { ...context, screenSizeState })}
+    {({ platformData, ...screenSizeState }) => (
+      <ComposedComponent
+        {...props}
+        isDesktop={isDesktop}
+        platformData={platformData}
+        screenSizeState={screenSizeState} >
+        {props.children}
+      </ComposedComponent>
+    )}
   </ScreenSizeConsumer>
 );


### PR DESCRIPTION
Refactors the withRowState and withScreenSize enhancers to use HOCs passing to props in
order to support using them with class components and composition in arbitrary order.

The disadvantage of doing it this way is that we have to be more careful to avoid props clashes than with the other method. To mitigate this concern I have rowStat, screenSizeState, and platformData separated.

This is a good discussion on the subject: https://twitter.com/acdlite/status/971598256454098944

