### PR TITLE
fix(Table): Fix SortBy

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -150,7 +150,7 @@ class Table extends PureComponent {
     });
   }
 
-  sortBy(key) {
+  sortBy = (key) => {
     let descending = this.state.descending;
     const mutatedData = [...this.state.mutatedData];
     if (this.props.onSort) {


### PR DESCRIPTION
Tuen sortBy into an arrow function in order to keep "this" context when
checking for props