### PR TITLE
Version 0.0.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-material-components",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "coming soon",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -3,7 +3,7 @@ import debounce from 'lodash.debounce';
 import styled from 'styled-components';
 import { contrastingColor } from '../../mixins/theme';
 
-export const InkBar = styled.div`
+export const TabsInkBar = styled.div`
   bottom: 0;
   height: 2px;
   position: absolute;
@@ -91,7 +91,7 @@ class TabBarComponent extends React.PureComponent {
         {tabs}
         {showInkbar &&
           this.mounted && (
-            <InkBar data-smc="InkBar" inkbarColor={inkbarColor} {...this.state.inkbarPosition} />
+            <TabsInkBar data-smc="TabsInkBar" inkbarColor={inkbarColor} {...this.state.inkbarPosition} />
           )}
       </TabBarContainer>
     );


### PR DESCRIPTION
### Tabs
* Renames Inkbar to avoid a namespace collision with the Navigation Inkbar.
  * **Breaking change**: The tabs inkbar's data-smc property has been renamed to
"TabsInkBar"