### PR TITLE
feat(Snackbar): Add Mobile Snackbar

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -9,11 +9,12 @@ export default class MyDocument extends Document {
     return (
       <html lang="en">
         <Head>
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
           <title>Styled Material Components</title>
           {styleTags}
         </Head>
         <body style={{ overflow: 'visible' }}>
-          <div className='root' style={{ width: '100%' }}>
+          <div className="root" style={{ width: '100%' }}>
             {main}
           </div>
           <NextScript />

--- a/pages/snackbar.js
+++ b/pages/snackbar.js
@@ -4,10 +4,11 @@ import { ThemeProvider, Button, Snackbar } from '../src';
 
 class SnackbarPage extends PureComponent {
   state = {
-    open: false,
+    single: false,
+    multi: false,
   };
 
-  handleClose = () => this.setState({ open: false });
+  handleClose = type => this.setState({ [type]: false });
 
   render() {
     return (
@@ -17,18 +18,34 @@ class SnackbarPage extends PureComponent {
           <ul>
             <li>open - boolean to open snackbar</li>
             <li>onRequestClose - function that sets open to false</li>
-            <li>message -
-              string for snackbar message. can alternatively pass in children to Snackbar</li>
+            <li>
+              message - string for snackbar message. can alternatively pass in children to Snackbar
+            </li>
             <li>autoHideDuration - pass in number in milliseconds; default is 4 seconds</li>
+            <li>
+              multiline - boolean to make snackbar display two lines instead of one. Only works when
+              the device is using a mobile-sized viewport
+            </li>
           </ul>
-          <Button primary raised onClick={() => this.setState({ open: true })}>
+          <StyledButton primary raised onClick={() => this.setState({ single: true })}>
             Open a basic snackbar
-          </Button>
+          </StyledButton>
+          <StyledButton primary raised onClick={() => this.setState({ multi: true })}>
+            Open a multi-line snackbar
+          </StyledButton>
           <Snackbar
-            open={this.state.open}
-            onRequestClose={this.handleClose}
+            open={this.state.single}
+            onRequestClose={() => this.handleClose('single')}
             autoHideDuration={1500}
-            message='this is a foodless snackbar :(' />
+            message="this is a foodless snackbar :("
+          />
+          <Snackbar
+            open={this.state.multi}
+            multiline
+            onRequestClose={() => this.handleClose('multi')}
+            autoHideDuration={1500}
+            message="This snackbar will display multiple lines on a mobile device, provided that the snackbar message is of a certain length. Multi-line snackbars are triggered with the 'multiline' prop."
+          />
         </div>
       </ThemeProvider>
     );
@@ -37,7 +54,10 @@ class SnackbarPage extends PureComponent {
 
 const StyledSnackbarPage = styled(SnackbarPage)`
   margin: 0 10%;
-  width: 80%;
+`;
+
+const StyledButton = Button.extend`
+  margin: 0 24px 24px 0;
 `;
 
 export default StyledSnackbarPage;


### PR DESCRIPTION
- utilize withScreenSize context provider to set a prop `mobile` on xs and sm screen sizes
- `mobile` prop used for changing styles conditionally on smaller screen sizes
- add `multiline` prop to indicate that a snackbar should take up two lines instead of one. only works when `mobile` prop has been triggered

Did not add Action Button functionality to snackbar at this time.