### PR TITLE
refactor(Contexts): Use official React 16.3 api

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "color": "^2.0.0",
-    "create-react-context": "^0.2.1",
     "eslint-config-concierge-auctions-base": "^0.0.6",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",

--- a/src/components/FlexGrid/Column.js
+++ b/src/components/FlexGrid/Column.js
@@ -209,7 +209,7 @@ const enhancer = compose(
 );
 
 const ColumnComponent = enhancer(
-  ({ className, children, ...props }, { screenSizeState, rowState }) => (
+  ({ className, children, screenSizeState, rowState, ...props }) => (
     <SizedColumn
       {...props}
       data-smc="Column"

--- a/src/components/FlexGrid/Row.js
+++ b/src/components/FlexGrid/Row.js
@@ -4,22 +4,11 @@
  * @description Defines a flex grid row that has props defined for
  * easily setting some common flex styles.
  */
-import React, { Component } from 'react';
+import React, { Component, createContext, forwardRef } from 'react';
 import styled from 'styled-components';
-import createReactContext from 'create-react-context';
 import { rowMixin } from '../../mixins/flex';
 
-/**
- * RowContext
- *
- * createReactContext is a polyfill for the new context api landing
- * soon in React. It creates a flux like architecture using react's
- * state instead of an external state system. the purpose of this
- * context is to be able to provide any subcomponent access to the
- * props of the parent row. This allows columns to change their styles
- * to reflect direction and positioning of the row that contains them.
- */
-const RowContext = createReactContext({
+const RowContext = createContext({
   horizontal: 'left',
   vertical: 'middle',
   distribution: null,
@@ -86,9 +75,13 @@ export const Row = styled(RowComponent)`
   ${props => rowMixin(props)}
 `;
 
-export const withRowState = fn => (props, context = {}) => (
-  <RowConsumer>
-    {rowState => fn(props, { ...context, rowState })}
-  </RowConsumer>
-);
-
+export function withRowState(WrappedComponent) {
+  const ComponentWithRowState = (props, ref) => (
+    <RowConsumer>
+      {rowState => <WrappedComponent {...props} rowState={rowState} ref={ref} />}
+    </RowConsumer>
+  );
+  const name = WrappedComponent.displayName || WrappedComponent.name;
+  ComponentWithRowState.displayName = `withRowState(${name})`;
+  return forwardRef(ComponentWithRowState);
+}

--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -103,7 +103,9 @@ class SnackbarComponent extends PureComponent {
   }
 }
 
-const Snackbar = styled(SnackbarComponent)`
+const Snackbar = styled(SnackbarComponent).attrs({
+  mobile: ({ screenSizeState }) => ['xs', 'sm'].includes(screenSizeState.screenSize),
+})`
   display: ${props => (props.open && !props.animateOut ? 'flex' : 'none')};
   position: fixed;
   left: ${props => (props.mobile ? 0 : '50%')};
@@ -121,6 +123,4 @@ const Snackbar = styled(SnackbarComponent)`
 
 const enhancer = compose(withScreenSize);
 
-export default enhancer(({ className, children, ...props }, { screenSizeState }) => (
-  <Snackbar {...props} mobile={['xs', 'sm'].includes(screenSizeState.screenSize)} />
-));
+export default enhancer(Snackbar);

--- a/src/contexts/ScreenSizeContext.js
+++ b/src/contexts/ScreenSizeContext.js
@@ -6,23 +6,12 @@
  * access the current screenSize. This is implmented using respondable.
  * All breakpoints are adjustable by the end user.
  */
-import React, { Component } from 'react';
-import createReactContext from 'create-react-context';
+import React, { Component, createContext, forwardRef } from 'react';
 import { withTheme } from 'styled-components';
 import respondable from 'respondable';
 import platform from 'platform';
 
-/**
- * Context
- *
- * createReactContext is a polyfill for the new context api landing
- * soon in React. It creates a flux like architecture using react's
- * state instead of an external state system. the purpose of this
- * context is to be able to provide any subcomponent access to the
- * screenSize state. This allows any component that needs to to adjust
- * their styles based on screenSize.
- */
-const Context = createReactContext({ size: 'server' });
+const Context = createContext({ size: 'server' });
 
 /**
  * ScreenSizeConsumer
@@ -140,8 +129,15 @@ class ScreenSizeContextBase extends Component {
 // withTheme gives us access to the theme without it being a Styled Component
 export const ScreenSizeContext = withTheme(ScreenSizeContextBase);
 
-export const withScreenSize = fn => (props, context = {}) => (
-  <ScreenSizeConsumer>
-    {screenSizeState => fn(props, { ...context, screenSizeState })}
-  </ScreenSizeConsumer>
-);
+export function withScreenSize(WrappedComponent) {
+  const ScreenSizeAwareComponent = (props, ref) => (
+    <ScreenSizeConsumer>
+      {screenSizeState =>
+        <WrappedComponent {...props} screenSizeState={screenSizeState} ref={ref} />
+      }
+    </ScreenSizeConsumer>
+  );
+  const name = WrappedComponent.displayName || WrappedComponent.name;
+  ScreenSizeAwareComponent.displayName = `screenSizeAware(${name})`;
+  return forwardRef(ScreenSizeAwareComponent);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,13 +1650,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.1.tgz#425a3d96f4b7690c2fbf20aed5aeae2e2007a959"
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
-
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2402,7 +2395,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2830,10 +2823,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 handlebars@^4.0.2:
   version "4.0.11"
@@ -4734,9 +4723,17 @@ prop-types-exact@1.1.1:
     has "^1.0.1"
     object.assign "^4.0.4"
 
-prop-types@15.6.0, prop-types@^15.5.4, prop-types@^15.6.0:
+prop-types@15.6.0, prop-types@^15.5.4:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
+prop-types@^15.6.0:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.3.1"
@@ -4846,8 +4843,8 @@ react-deep-force-update@^2.1.1:
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
 react-dom@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.0.tgz#b318e52184188ecb5c3e81117420cca40618643e"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -4875,8 +4872,8 @@ react-tunnels@^1.0.2:
   resolved "https://registry.yarnpkg.com/react-tunnels/-/react-tunnels-1.0.2.tgz#cd03aaaeb47305e38d471303e5569dd2427a01b9"
 
 react@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -6225,8 +6222,8 @@ webpack@3.6.0:
     yargs "^8.0.2"
 
 whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This removes the polyfill in favor of the real thing. There is a
breaking change in that I have reverted the 'functional hoc' style for
the withScreenSize and withRowState contexts because it comes with side
effects that are unintentional with other apis that were exposed by
react 16.3 update. Namely this means the forwardRef api.

BREAKING CHANGE:
Usage of withScreenSize/withRowState must be updated.