### PR TITLE
fix(Column): fix breaking changes from ScreenSizeContext

### DIFF
--- a/src/components/FlexGrid/Column.js
+++ b/src/components/FlexGrid/Column.js
@@ -26,9 +26,8 @@ import { withRowState } from './Row';
  * @param {String} key             The subkey to return from the prop object
  */
 const getResponsiveProp = (props, layout, screenSize, lowerScreenSize, key) => {
-  const responsiveProp = props[screenSize]
-    || props[lowerScreenSize]
-    || props[layout.defaultScreenSize];
+  const responsiveProp =
+    props[screenSize] || props[lowerScreenSize] || props[layout.defaultScreenSize];
   if (!responsiveProp) return null;
   if (key) return responsiveProp[key];
   return responsiveProp;
@@ -148,20 +147,14 @@ const flexSizeMixin = ({
   theme: { layout },
   ...props
 }) => {
-  const targetSize = size || getResponsiveProp(
-    props,
-    layout,
-    screenSize,
-    lowerScreenSize,
-    'size'
-  );
+  const targetSize = size || getResponsiveProp(props, layout, screenSize, lowerScreenSize, 'size');
   if (!targetSize) return '';
   const value = calcMinus(
     computePercentage(targetSize, layout.baseGridSize),
     noGutters ? '0px' : layout.gutterSize,
-    noGutters ? '0px' : layout.gutterSize,
+    noGutters ? '0px' : layout.gutterSize
   );
-  return css `
+  return css`
     flex-basis: ${value};
     max-width: ${value};
   `;
@@ -203,24 +196,19 @@ const SizedColumn = styled.div`
  * added to the end of the generated classNames for that component. Because
  * order of classes matters in css this className takes precedent.
  */
-const enhancer = compose(
-  withScreenSize,
-  withRowState,
+const enhancer = compose(withScreenSize, withRowState);
+
+const BaseColumnComponent = ({ className, children, screenSizeState, rowState, ...props }) => (
+  <SizedColumn
+    {...props}
+    data-smc="Column"
+    row={rowState}
+    screenSize={screenSizeState.screenSize}
+    lowerScreenSize={screenSizeState.lowerScreenSize}
+    className={className}
+  >
+    {children}
+  </SizedColumn>
 );
 
-const ColumnComponent = enhancer(
-  ({ className, children, screenSizeState, rowState, ...props }) => (
-    <SizedColumn
-      {...props}
-      data-smc="Column"
-      row={rowState}
-      screenSize={screenSizeState.screenSize}
-      lowerScreenSize={screenSizeState.lowerScreenSize}
-      className={className}>
-      {children}
-    </SizedColumn>
-  )
-);
-
-export const Column = styled(ColumnComponent)`
-`;
+export const Column = styled(enhancer(BaseColumnComponent))``;

--- a/src/components/FlexGrid/Row.js
+++ b/src/components/FlexGrid/Row.js
@@ -4,7 +4,7 @@
  * @description Defines a flex grid row that has props defined for
  * easily setting some common flex styles.
  */
-import React, { Component, createContext, forwardRef } from 'react';
+import React, { Component, createContext } from 'react';
 import styled from 'styled-components';
 import { rowMixin } from '../../mixins/flex';
 
@@ -72,16 +72,14 @@ class RowComponent extends Component {
 }
 
 export const Row = styled(RowComponent)`
-  ${props => rowMixin(props)}
+  ${props => rowMixin(props)};
 `;
 
 export function withRowState(WrappedComponent) {
-  const ComponentWithRowState = (props, ref) => (
-    <RowConsumer>
-      {rowState => <WrappedComponent {...props} rowState={rowState} ref={ref} />}
-    </RowConsumer>
+  const ComponentWithRowState = props => (
+    <RowConsumer>{rowState => <WrappedComponent {...props} rowState={rowState} />}</RowConsumer>
   );
   const name = WrappedComponent.displayName || WrappedComponent.name;
   ComponentWithRowState.displayName = `withRowState(${name})`;
-  return forwardRef(ComponentWithRowState);
+  return ComponentWithRowState;
 }

--- a/src/contexts/ScreenSizeContext.js
+++ b/src/contexts/ScreenSizeContext.js
@@ -6,7 +6,7 @@
  * access the current screenSize. This is implmented using respondable.
  * All breakpoints are adjustable by the end user.
  */
-import React, { Component, createContext, forwardRef } from 'react';
+import React, { Component, createContext } from 'react';
 import { withTheme } from 'styled-components';
 import respondable from 'respondable';
 import platform from 'platform';
@@ -38,7 +38,8 @@ class ScreenSizeContextBase extends Component {
         product: platform.product,
         osFamily: platform.os ? platform.os.family : null,
         majorVersion: platform.version ? parseInt(platform.version.split('.')[0], 10) : -1,
-        majorOsVersion: platform.os && platform.os.version ? parseInt(platform.os.version.split('.')[0], 10) : -1,
+        majorOsVersion:
+          platform.os && platform.os.version ? parseInt(platform.os.version.split('.')[0], 10) : -1,
       },
     });
     // Initialize Respondable
@@ -87,7 +88,7 @@ class ScreenSizeContextBase extends Component {
   getNextLowestScreenSize = (active) => {
     const index = this.props.theme.layout.screenSizePriority.indexOf(active);
     const length = this.props.theme.layout.screenSizePriority.length;
-    if (index !== (length - 1)) return this.props.theme.layout.screenSizePriority[index + 1];
+    if (index !== length - 1) return this.props.theme.layout.screenSizePriority[index + 1];
     return active;
   };
 
@@ -107,11 +108,12 @@ class ScreenSizeContextBase extends Component {
    * @param {String} active  current active screenSize
    * @param {String} largest largest of active screenSizes if any compete
    */
-  setScreenSize = (active, largest) => this.setState({
-    screenSize: largest,
-    lowerScreenSize: this.getNextLowestScreenSize(largest),
-    higherScreenSize: this.getNextHighestScreenSize(largest),
-  });
+  setScreenSize = (active, largest) =>
+    this.setState({
+      screenSize: largest,
+      lowerScreenSize: this.getNextLowestScreenSize(largest),
+      higherScreenSize: this.getNextHighestScreenSize(largest),
+    });
 
   render() {
     return (
@@ -130,14 +132,12 @@ class ScreenSizeContextBase extends Component {
 export const ScreenSizeContext = withTheme(ScreenSizeContextBase);
 
 export function withScreenSize(WrappedComponent) {
-  const ScreenSizeAwareComponent = (props, ref) => (
+  const ScreenSizeAwareComponent = props => (
     <ScreenSizeConsumer>
-      {screenSizeState =>
-        <WrappedComponent {...props} screenSizeState={screenSizeState} ref={ref} />
-      }
+      {screenSizeState => <WrappedComponent {...props} screenSizeState={screenSizeState} />}
     </ScreenSizeConsumer>
   );
   const name = WrappedComponent.displayName || WrappedComponent.name;
   ScreenSizeAwareComponent.displayName = `screenSizeAware(${name})`;
-  return forwardRef(ScreenSizeAwareComponent);
+  return ScreenSizeAwareComponent;
 }


### PR DESCRIPTION
This PR fixes a bug that was breaking most of the SMC pages where Column was not able to be converted to a styled component due to some effect of returning a forwardRef instead of the actual component. Per @brad-decker, the forwardRef was only a failsafe so we're removing it for now. 