### PR TITLE
fix Portal console warning

### DIFF
--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -6,7 +6,7 @@ import { Shift } from './Shift';
 let smcPortal;
 
 export class Portal extends Component {
-  defaultProps = {
+  static defaultProps = {
     shift: false,
     direction: 'left',
   };


### PR DESCRIPTION
This just sets `defaultProps` as a static property on `Portal` to remove the console warnings about setting `defaultProps` as an instance property.