### PR TITLE
feat(icon): add onClick

### DIFF
--- a/pages/icons/index.js
+++ b/pages/icons/index.js
@@ -11,7 +11,6 @@ import {
   ListItemText,
   ListSubheader,
   ThemeProvider,
-  withRipple,
 } from '../../src';
 import { iconList } from './assets';
 import { AddIcon, FileDownloadIcon, FileUploadIcon } from '../../src/icons';
@@ -20,12 +19,12 @@ const StyledButton = Button.extend`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 0 16px;
+  margin: 0 16px 16px;
   align-self: center;
 `;
 
 const StyledFab = FloatingActionButton.extend`
-  margin: 0 16px;
+  margin: 0 16px 16px;
 `;
 
 const StyledDivider = Divider.extend`
@@ -36,7 +35,7 @@ const IconsPage = ({ className }) => (
   <ThemeProvider>
     <section className={className}>
       <h1>Icons</h1>
-      <GridList>{iconList.map((icon, i) => <GridTile>{icon}</GridTile>)}</GridList>
+      <GridList>{iconList.map(icon => <GridTile>{icon}</GridTile>)}</GridList>
       <h1>Icon Buttons</h1>
       <GridList>
         <StyledButton primary raised>
@@ -72,6 +71,9 @@ const IconsPage = ({ className }) => (
             </ListItem>
             <ListItem>
               <ListItemText primary="size" secondary="Sets the height and width of the icon." />
+            </ListItem>
+            <ListItem>
+              <ListItemText primary="onClick" secondary="Accepts an onClick function." />
             </ListItem>
           </List>
         </GridTile>

--- a/src/icons/icons.js
+++ b/src/icons/icons.js
@@ -64,6 +64,7 @@ const IconComponent = props => (
     data-smc="Icon"
     fill={props.fill || DEFAULT_FILL}
     height={props.size || DEFAULT_SIZE}
+    onClick={props.onClick}
     viewBox=" 0 0 24 24"
     width={props.size || DEFAULT_SIZE}
     xlmns="http://www.w3.org/2000/svg"
@@ -72,4 +73,6 @@ const IconComponent = props => (
   </svg>
 );
 
-export const Icon = styled(IconComponent)``;
+export const Icon = styled(IconComponent)`
+  ${props => props.onClick && 'cursor: pointer'};
+`;


### PR DESCRIPTION
This PR allows Icon to accept an `onClick` function. Previously, we've been wrapping the icons in divs to accommodate onClick functions. 