### PR TITLE
build(react & r-dom): Move to ddeps, 16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,10 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "color": "^2.0.0",
-    "eslint-config-concierge-auctions-base": "^0.0.6",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.0",
     "platform": "^1.3.5",
-    "react": "^16.0.0",
     "react-tunnels": "^1.0.2",
     "recompose": "^0.26.0",
     "respondable": "^1.0.1",
@@ -49,14 +47,19 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.10.0",
+    "eslint-config-concierge-auctions-base": "^0.0.6",
     "eslint-config-concierge-auctions-react": "^0.0.7",
     "husky": "^0.14.3",
     "next": "^4.1.4",
     "now": "^9.0.1",
-    "react-dom": "^16.0.0",
+    "react": "^16.3.2",
+    "react-dom": "^16.3.2",
     "stylelint": "^9.1.1",
     "stylelint-config-standard": "^18.1.0",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.2.2"
+  },
+  "peerDependencies": {
+    "react": ">= 0.14.0 < 17.0.0-0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4842,9 +4842,9 @@ react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
-react-dom@^16.0.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.0.tgz#b318e52184188ecb5c3e81117420cca40618643e"
+react-dom@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -4871,9 +4871,9 @@ react-tunnels@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-tunnels/-/react-tunnels-1.0.2.tgz#cd03aaaeb47305e38d471303e5569dd2427a01b9"
 
-react@^16.0.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.3.0.tgz#fc5a01c68f91e9b38e92cf83f7b795ebdca8ddff"
+react@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Updates react and react-dom to 16.3 and moves react to being a dev
dependency and a peer dependency (mirroring versions from
styled-components). Also moves the eslint dependency to being a
devdep. These changes facilitate using `yarn link` to develop using
local changes.