### PR TITLE
Added missing name attribute to Area component

### DIFF
--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -183,6 +183,7 @@ class TextFieldComponent extends PureComponent {
               onChange={this.onChange}
               onFocus={this.onFocus}
               onBlur={this.onBlur}
+              name={this.props.name}
               className={'smc-text-field-area'}
               innerRef={(ref) => {
                 this.textArea = ref;


### PR DESCRIPTION
I wasn't able to control textarea through the TextField component, because of a missing name attribute on the Area component.
This PR contains the missing attribute.