### PR TITLE
fix(TextField): Add innerRef

### DIFF
--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -205,6 +205,7 @@ class TextFieldComponent extends PureComponent {
               onFocus={this.onFocus}
               onBlur={this.onBlur}
               name={this.props.name}
+              {...(this.props.inputRef ? { innerRef: this.props.inputRef } : {})}
               className={'smc-text-field-input'}
             />
 


### PR DESCRIPTION
This adds in the the ability to pass a prop to the Text Field called inputRef, and uses it as the innerRef on the Input field itself.