### PR TITLE
feat(menu): close by anchor

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -21,10 +21,10 @@ class MenuComponent extends Component {
   }
 
   handleClick = (event) => {
-    if (this.menu.contains(event.target)) return;
+    if (this.menu.contains(event.target) || this.props.anchorEl === event.target) return;
     this.props.onClose && this.props.onClose(event);
   };
-  
+
   recalculatePosition = debounce(() => {
     const { props: { anchorEl }, menu } = this;
     if (!anchorEl || !menu) return;


### PR DESCRIPTION
In the current implementation, the `anchorEl` is always covered by the menu that it opens,
and therefore cannot be clicked. When styles are passed in to override that behavior, the `anchorEl`
closes then reopens the menu by firing `onClose` then flipping the `open` value in state.

This changes that behavior so that the menu will stay closed by preventing the `onClose` method from being fired when the `anchorEl` is clicked.