### PR TITLE
feat(dialog): open from top/bottom

### DIFF
--- a/pages/dialog.js
+++ b/pages/dialog.js
@@ -18,6 +18,8 @@ export default class dialogsPage extends Component {
     withoutTitle: false,
     left: false,
     right: false,
+    top: false,
+    bottom: false,
     customSize: false,
   };
 
@@ -60,6 +62,18 @@ export default class dialogsPage extends Component {
             closeDialog={() => this.closeDialog('right')}
           />
           <ExampleDialog
+            fullscreen
+            attachment="top"
+            open={this.state.top}
+            closeDialog={() => this.closeDialog('top')}
+          />
+          <ExampleDialog
+            fullscreen
+            attachment="bottom"
+            open={this.state.bottom}
+            closeDialog={() => this.closeDialog('bottom')}
+          />
+          <ExampleDialog
             open={this.state.customSize}
             closeDialog={() => this.closeDialog('customSize')}
             title="Pass your own width prop"
@@ -69,13 +83,19 @@ export default class dialogsPage extends Component {
           <Button onClick={() => this.openDialog('withoutTitle')}>
             Open a dialog without a title
           </Button>
-          <Button onClick={() => this.openDialog('left')}>
-            Open a full screen dialog from the left
+          <Button onClick={() => this.openDialog('customSize')}>Open a custom-sized Dialog.</Button>
+          <Button onClick={() => this.openDialog('top')}>
+            Open a full screen dialog from the top
           </Button>
           <Button onClick={() => this.openDialog('right')}>
             Open a full screen dialog from the right
           </Button>
-          <Button onClick={() => this.openDialog('customSize')}>Open a custom-sized Dialog.</Button>
+          <Button onClick={() => this.openDialog('bottom')}>
+            Open a full screen dialog from the bottom
+          </Button>
+          <Button onClick={() => this.openDialog('left')}>
+            Open a full screen dialog from the left
+          </Button>
         </div>
       </ThemeProvider>
     );

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -29,6 +29,8 @@ class DialogComponent extends React.Component {
       open: this.props.open,
       left: this.props.attachment === 'left',
       right: this.props.attachment === 'right',
+      top: this.props.attachment === 'top',
+      bottom: this.props.attachment === 'bottom',
     });
 
     return (
@@ -95,6 +97,16 @@ export default styled(DialogComponent) `
     &.right {
       right: 0;
       transform: translateX(107%);
+    }
+
+    &.top {
+      top: 0;
+      transform: translateY(-107%);
+    }
+
+    &.bottom {
+      bottom: 0;
+      transform: translateY(107%);
     }
 
     &.open {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -59,7 +59,7 @@ export const TooltipContents = styled.div`
   )};
   display: flex;
   align-items: center;
-  justify-content: center; 
+  justify-content: center;
 `;
 
 export const TooltipIcon = Icon.extend`


### PR DESCRIPTION
Add option to open full screen dialogs from the top and bottom of the screen