### PR TITLE
fix(Menu): find offsetParent

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -4,6 +4,7 @@ import debounce from 'lodash.debounce';
 import elevation from '../../mixins/elevation';
 import MenuList from './MenuList';
 import MenuItem from './MenuItem';
+import { isDescendant } from '../../helpers';
 
 class MenuComponent extends Component {
   componentDidMount() {
@@ -21,7 +22,7 @@ class MenuComponent extends Component {
   }
 
   handleClick = (event) => {
-    if (this.menu.contains(event.target) || this.props.anchorEl === event.target) return;
+    if (this.menu.contains(event.target) || isDescendant(this.props.anchorEl, event.target)) return;
     this.props.onClose && this.props.onClose(event);
   };
 
@@ -30,8 +31,11 @@ class MenuComponent extends Component {
     if (!anchorEl || !menu) return;
     const menuRect = this.menu.getBoundingClientRect();
     const anchorRect = anchorEl.getBoundingClientRect();
-    const anchorLeft = anchorRect.x + window.scrollX;
-    const anchorTop = anchorRect.y + window.scrollY;
+    const offsetRect = anchorEl.offsetParent.getBoundingClientRect();
+    /* eslint-disable no-mixed-operators */
+    const anchorLeft = anchorRect.x + window.scrollX - offsetRect.x;
+    const anchorTop = anchorRect.y + window.scrollY + anchorRect.height - offsetRect.y;
+    /* eslint-enable no-mixed-operators */
     const overBottom = anchorTop + menuRect.height > window.innerHeight;
     const overRight = anchorLeft + menuRect.width > window.innerWidth;
     this.menu.style.top = `${anchorTop -

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -28,7 +28,7 @@ const MenuItem = styled(MenuItemComponent) `
   &:hover {
     background-color: rgba(232, 232, 232, 1);
     cursor: pointer;
-  } 
+  }
 
   &:focus {
     background-color: rgba(232, 232, 232, 1);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,12 @@
+
+// This is a helper for determining if there is an ancestral relationship between two components
+export const isDescendant = (parent, child) => {
+  let node = child.parentNode;
+  while (node !== null) {
+    if (node === parent) {
+      return true;
+    }
+    node = node.parentNode;
+  }
+  return false;
+};


### PR DESCRIPTION
Account for offsetParent of the anchorEl when computing the menu's
position.

Protect against accidental openings by checking that a clicked element
is an ancestor of the anchor element and not just the anchor element
itself.