### PR TITLE
fix(Menu): rollback breaking change

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -26,7 +26,7 @@ class MenuComponent extends Component {
     this.props.onClose && this.props.onClose(event);
   };
 
-  recalculatePosition = () => {
+  recalculatePosition = debounce(() => {
     const { props: { anchorEl }, menu } = this;
     if (!anchorEl || !menu) return;
     const menuRect = this.menu.getBoundingClientRect();
@@ -34,7 +34,7 @@ class MenuComponent extends Component {
     const offsetRect = anchorEl.offsetParent.getBoundingClientRect();
     /* eslint-disable no-mixed-operators */
     const anchorLeft = anchorRect.x + window.scrollX - offsetRect.x;
-    const anchorTop = anchorRect.y + window.scrollY + anchorRect.height - offsetRect.y;
+    const anchorTop = anchorRect.y + window.scrollY - offsetRect.y;
     /* eslint-enable no-mixed-operators */
     const overBottom = anchorTop + menuRect.height > window.innerHeight;
     const overRight = anchorLeft + menuRect.width > window.innerWidth;
@@ -42,7 +42,7 @@ class MenuComponent extends Component {
       (overBottom ? menuRect.height - anchorRect.height : 0)}px`;
     this.menu.style.left = `${anchorLeft -
       (overRight ? menuRect.width - anchorRect.width : 0)}px`;
-  }
+  }, 0);
 
   render() {
     const { className, children, menuItems, open, onClose } = this.props;
@@ -53,7 +53,7 @@ class MenuComponent extends Component {
         className={`${className} smc-Menu`}
         ref={(ref) => {
           this.menu = ref;
-          debounce(this.recalculatePosition, 0);
+          this.recalculatePosition();
         }}
       >
         {renderChildren && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,6 +562,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "7.0.0-beta.42"
 
+"@babel/plugin-syntax-flow@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.0.0-beta.49.tgz#5b3f0b65ca9660534535643b82530fb1d58e63ee"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
 "@babel/plugin-syntax-jsx@7.0.0-beta.42":
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0-beta.42.tgz#92ef7807bbec0e12a49815a409822262cbaa7ddd"
@@ -743,6 +749,13 @@
   dependencies:
     "@babel/helper-builder-binary-assignment-operator-visitor" "7.0.0-beta.49"
     "@babel/helper-plugin-utils" "7.0.0-beta.49"
+
+"@babel/plugin-transform-flow-strip-types@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.0.0-beta.49.tgz#f02a26528e94b2c1d11d9573b63ee5782d4f2af9"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-syntax-flow" "7.0.0-beta.49"
 
 "@babel/plugin-transform-for-of@7.0.0-beta.42":
   version "7.0.0-beta.42"
@@ -1124,6 +1137,13 @@
     browserslist "^3.0.0"
     invariant "^2.2.2"
     semver "^5.3.0"
+
+"@babel/preset-flow@^7.0.0-beta.46":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0-beta.49.tgz#10cbee1a60db207120a4443c54c0ca5f734eb390"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.49"
+    "@babel/plugin-transform-flow-strip-types" "7.0.0-beta.49"
 
 "@babel/preset-react@7.0.0-beta.42":
   version "7.0.0-beta.42"


### PR DESCRIPTION
This PR reverts a change that moved debounce out of a class method which was causing anchor positioning to not work. 

There will most likely be a follow-up PR from @AriLFrankel or myself that allows the menu anchor positioning to be set with a prop: `top-start`, `bottom-middle`, etc. 