### PR TITLE
Fix context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-material-components",
-  "version": "0.0.54",
+  "version": "0.0.55-0",
   "description": "coming soon",
   "main": "dist/index.js",
   "scripts": {

--- a/src/contexts/ScreenSizeContext.js
+++ b/src/contexts/ScreenSizeContext.js
@@ -117,11 +117,7 @@ class ScreenSizeContextBase extends Component {
 
   render() {
     return (
-      <Context.Provider
-        value={{
-          ...this.state,
-        }}
-      >
+      <Context.Provider value={this.state}>
         {this.props.children}
       </Context.Provider>
     );


### PR DESCRIPTION
```js
  render() {
    return (
      <Context.Provider
        value={{
          ...this.state,
        }}
      >
        {this.props.children}
      </Context.Provider>
    );
}
```

This was the state of the render method of the context provider before I changed it. This spreading of state is an identified anti pattern by Dan Abramov because it creates a new object everytime the provider renders and triggers re-renders of all context consumers instead of only re-rendering when state re-renders. This PR includes a pre-release tag to 55-0, installable now via yarn add styled-material-components@RC