### PR TITLE
feat(chip): update focus style

### DIFF
--- a/src/components/Chip.js
+++ b/src/components/Chip.js
@@ -1,31 +1,61 @@
 import React, { PureComponent } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import typography from '../mixins/typography';
 import elevation, { elevationTransition } from '../mixins/elevation';
 import { CancelIcon } from '../icons';
 
+const clickableStyles = css`
+  :hover {
+    ::before {
+      opacity: 0.08;
+    }
+  }
+  :focus {
+    ::before {
+      opacity: 0.12;
+    }
+    :active {
+      ${elevationTransition};
+      ${elevation(3)};
+    }
+  }
+`;
+
+const removableStyles = css`
+  :focus {
+    ::before {
+      opacity: 0.12;
+    }
+  }
+`;
+
 const ChipWrapper = styled.div`
+  position: relative;
+  &::before {
+    content: '';
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.87);
+    opacity: 0;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 16px;
+    pointer-events: none;
+  }
+  outline: none;
   display: inline-flex;
   justify-content: space-between;
   align-items: center;
   margin: 8px;
-  background-color: rgba(0, 0, 0, 0.08);
+  background-color: #e0e0e0;
   height: 32px;
   border-radius: 16px;
   font-size: 13px;
   color: ${props => props.theme.textColors.primary};
-  ${props =>
-    props.clickable &&
-    `
-    :hover {
-      background-color: #CECECE
-    }`};
   ${props => props.removed && 'display: none'};
-  :focus {
-    outline: none;
-    ${elevationTransition};
-    ${elevation(3)};
-  }
+  ${({ removable }) => removable && removableStyles};
+  ${({ clickable }) => clickable && clickableStyles};
   /* Disable text highlighting of Chip labels */
   -webkit-touch-callout: none; /* iOS Safari */
   -webkit-user-select: none; /* Safari */
@@ -108,6 +138,7 @@ class ChipComponent extends PureComponent {
         onKeyDown={this.handleKeyDown}
         tabIndex={0}
         clickable={onClick}
+        removable={removable || onDelete}
         removed={removed}
       >
         {avatar && <ChipAvatar>{avatar}</ChipAvatar>}


### PR DESCRIPTION
This PR is a small iteration towards matching MD2 spec for Chip component.

This adds the correct styles for hover, focus, and clicked states. 

After discussion with @nataliaisabelle on our interpretations of the MD2 spec, these are the implemented changes:

- Chips that are clickable have a hover state, focused state, and clicked state
  - MD2 clicked state is what was previously the MD1 focused state
- Chips that are removable but not clickable have a focused state but no hover state
  - The Remove Icon has a hover state
- Chips that are neither clickable nor removable have none of the above