### PR TITLE
fix(Pages): Remove theme override

### DIFF
--- a/pages/avatars.js
+++ b/pages/avatars.js
@@ -19,7 +19,7 @@ const CodeBlock = styled.div`
 `;
 
 const AvatarsPage = () => (
-  <ThemeProvider theme={{ primary: "#03A9F4" }}>
+  <ThemeProvider>
     <h1>Avatars</h1>
     Avatars can accept first and last name and return initials
     <CodeBlock> {'<Avatar name="Bruce Wayne" />'}</CodeBlock>

--- a/pages/bottomsheets.js
+++ b/pages/bottomsheets.js
@@ -38,7 +38,7 @@ export default class PortalPage extends Component<
 
   render() {
     return (
-      <ThemeProvider theme={{ primary: "#03A9F4" }}>
+      <ThemeProvider>
         <PageContainer>
           <h1>Modal Bottomsheet!</h1>
           <BottomSheet

--- a/pages/buttons.js
+++ b/pages/buttons.js
@@ -51,7 +51,7 @@ class ButtonsPage extends React.PureComponent<
 
   render() {
     return (
-      <ThemeProvider theme={{ primary: "#03A9F4" }}>
+      <ThemeProvider>
         <div className={this.props.className}>
           <h1>Flat Buttons</h1>
           <GridList>

--- a/pages/cards.js
+++ b/pages/cards.js
@@ -29,7 +29,7 @@ type CardsPagePropsType = {|
 |};
 
 const CardsPage = ({ className }: CardsPagePropsType) => (
-  <ThemeProvider theme={{ primary: "#03A9F4" }}>
+  <ThemeProvider>
     <div className={className}>
       <h1>Card</h1>
       <h5>This card will elevate more on hover</h5>

--- a/pages/checkboxes.js
+++ b/pages/checkboxes.js
@@ -8,8 +8,7 @@ import {
   Box,
   CheckMark,
   List,
-  ListItem,
-  defaultTheme
+  ListItem
 } from "../src";
 
 const StyledCheckbox = Checkbox.extend`
@@ -77,7 +76,7 @@ class CheckboxesPage extends PureComponent<
   render() {
     const { checked } = this.state;
     return (
-      <ThemeProvider theme={defaultTheme}>
+      <ThemeProvider>
         <List>
           <h1 style={{ marginLeft: 25 }}>Checkboxes</h1>
           <ListItem>

--- a/pages/drawer.js
+++ b/pages/drawer.js
@@ -54,7 +54,7 @@ export default class PortalPage extends Component<
 
   render() {
     return (
-      <ThemeProvider theme={{ primary: "#03A9F4" }}>
+      <ThemeProvider>
         <PageContainer>
           <h1>Temporary Drawers!</h1>
           <Drawer

--- a/pages/gridlists.js
+++ b/pages/gridlists.js
@@ -49,7 +49,7 @@ type GridListsPagePropsType = {|
 |};
 
 const GridListsPage = ({ className }: GridListsPagePropsType) => (
-  <ThemeProvider theme={{ primary: "#03A9F4" }}>
+  <ThemeProvider>
     <div className={className}>
       <h1>Grid list</h1>
       <h3>Row</h3>

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,7 +8,7 @@ import List from "../src/components/List/List";
 import ListItem from "../src/components/List/ListItem";
 
 const HomePage = ({ className }) => (
-  <MaterialThemeProvider theme={{ primary: "#03A9F4" }}>
+  <MaterialThemeProvider>
     <List className={className}>
       <h1>Styled Material Components</h1>
       <ListItem>

--- a/pages/lists.js
+++ b/pages/lists.js
@@ -15,7 +15,7 @@ type ListsPagePropsType = {|
 |};
 
 const ListsPage = ({ className }: ListsPagePropsType) => (
-  <ThemeProvider theme={{ primary: "#03A9F4" }}>
+  <ThemeProvider>
     <div className={className}>
       <h1>List with Avatar</h1>
       <div className="list">

--- a/pages/menus.js
+++ b/pages/menus.js
@@ -95,7 +95,7 @@ class MenusPage extends Component {
     ];
 
     return (
-      <ThemeProvider theme={{ primary: '#03A9F4' }}>
+      <ThemeProvider>
         <PageWithBottomPadding>
           <h1>Menus</h1>
           <h2>Standalone Menu</h2>

--- a/pages/sliders.js
+++ b/pages/sliders.js
@@ -75,7 +75,7 @@ class SlidersPageBase extends PureComponent<
   render() {
     const { disabled } = this.state;
     return (
-      <ThemeProvider theme={{ primary: "#03A9F4" }}>
+      <ThemeProvider>
         <div className={this.props.className}>
           <div>
             <h1>Sliders</h1>

--- a/pages/snackbar.js
+++ b/pages/snackbar.js
@@ -36,7 +36,7 @@ class SnackbarPage extends PureComponent<
 
   render() {
     return (
-      <ThemeProvider theme={{ primary: "#03A9F4" }}>
+      <ThemeProvider>
         <div className={this.props.className}>
           <h1>Snackbar</h1>
           <ul>

--- a/pages/tabs.js
+++ b/pages/tabs.js
@@ -75,7 +75,7 @@ class ControlledTabs extends React.Component<
 }
 
 const TabsPage = () => (
-  <ThemeProvider theme={{ primary: "#03A9F4" }}>
+  <ThemeProvider>
     <PageContainer>
       <Content>
         <h1>Tabs</h1>

--- a/pages/text-fields.js
+++ b/pages/text-fields.js
@@ -41,7 +41,7 @@ class TextFieldPage extends PureComponent<
 
   render() {
     return (
-      <ThemeProvider theme={{ primary: "#03A9F4" }}>
+      <ThemeProvider>
         <div className={this.props.className}>
           <h1>Text Fields</h1>
 


### PR DESCRIPTION
### Summary of changes:
 - Removes the override on some pages that set the theme primary color to a light blue. The default theme primary color will now be used in all pages.

### Behaviors that should be QA'd:
 - All pages use the purple default theme color rather than the light blue override; Note that the radio buttons on the menus page are not SMC components, so they use the browser default (which is close to the old primary color, at least on my version of Chrome)


### Github Issues closed by this PR:
 - Progresses #315 
