### PR TITLE
 allow Dialog to close on outside click

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@
  Joseph Strandmo <josephstrandmo@gmail.com>
  danielstclair <danielallanstclair@gmail.com>
  Brandon Clark <yhbrandon@gmail.com>
+ brian pursell <brian@bittermelon.io>

--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -12,11 +12,22 @@ import { Portal } from '../Portal/index.js';
 class DialogComponent extends React.Component {
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyDown);
+    document.addEventListener('mousedown', this.handleOutsideClick);
+    document.addEventListener('touchstart', this.handleOutsideClick);
   }
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeyDown);
+    document.removeEventListener('mousedown', this.handleOutsideClick);
+    document.removeEventListener('touchstart', this.handleOutsideClick);
   }
+
+  dialog = React.createRef();
+
+  handleOutsideClick = (event) => {
+    if (this.dialog.current && this.dialog.current.contains(event.target)) return;
+    this.props.closeOnOutsideClick && this.props.closeOnOutsideClick();
+  };
 
   handleKeyDown = (event) => {
     if (event.keyCode === 27) {
@@ -64,7 +75,7 @@ const notFullScreenStyles = css`
   ${elevation(24)};
 `;
 
-export default styled(DialogComponent) `
+export default styled(DialogComponent)`
   width: 100%;
   height: 100%;
   display: flex;


### PR DESCRIPTION
### Summary of changes:
 - Added prop to close Dialog on outside click.

### Behaviors that should be QA'd:
 - The Dialog box should close when a user clicks or touches outside the Dialog component

### Github Issues closed by this PR:
 - Resolves #323 
