### PR TITLE
fix(Snackbar): interpolate animations

### DIFF
--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import { compose } from 'recompose';
 import { withScreenSize } from '../contexts/ScreenSizeContext';
 
@@ -49,7 +49,7 @@ const Message = styled.div`
 `;
 
 const SnackbarWrapper = styled.div`
-  animation: ${props => (props.animation ? `${props.animation} .3s linear` : 0)};
+  animation: ${props => (css`${props.animation}` ? css`${props.animation} .3s linear` : 0)};
   bottom: ${(props) => {
     if (props.open && !props.animateOut) {
       return '0px';


### PR DESCRIPTION
You can no longer just plop a keyframe into a text string, you must
interpolate it with css inside of interpolations.

ok:
```js
const x = styled.div`animation: ${keyframe}`;
```

not ok:
```js
const x = styled.div`animation: ${props => props.animation &&
keyframe}`;
```
ok:
```js
const x = styled.div`animation: ${props => props.animation &&
css`${keyframe}`};
```

styled-components doesn't check what is returned from your
interpolations and run further interpolations on them.

### Summary of changes:
 -

### Behaviors that should be QA'd:
 -

-- The following sections are optional. Delete any that do not apply. --
### Known bugs that will be handled in a different PR:
 -

### Related functionality that will be handled in a different PR:
 -

### Github Issues closed by this PR:
 - Resolves #
