### PR TITLE
Unfocus first MenuList item on page load

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@
  danielstclair <danielallanstclair@gmail.com>
  Brandon Clark <yhbrandon@gmail.com>
  brian pursell <brian@bittermelon.io>
+ joshuapawlik <joshawesome12@yahoo.com>

--- a/src/components/Menu/MenuList.js
+++ b/src/components/Menu/MenuList.js
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 
 class MenuListComponent extends React.Component {
-  
   menuList = React.createRef();
 
   handleKeyDown = (event) => {

--- a/src/components/Menu/MenuList.js
+++ b/src/components/Menu/MenuList.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 class MenuListComponent extends React.Component {
   componentDidMount() {
-    findDOMNode(this.menuList.current).firstChild.focus();
+    
   }
 
   menuList = React.createRef();

--- a/src/components/Menu/MenuList.js
+++ b/src/components/Menu/MenuList.js
@@ -2,10 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 class MenuListComponent extends React.Component {
-  componentDidMount() {
-
-  }
-
+  
   menuList = React.createRef();
 
   handleKeyDown = (event) => {

--- a/src/components/Menu/MenuList.js
+++ b/src/components/Menu/MenuList.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 import styled from 'styled-components';
 
 class MenuListComponent extends React.Component {
   componentDidMount() {
-    
+
   }
 
   menuList = React.createRef();


### PR DESCRIPTION
### Summary of changes:
 - This will unfocus the first MenuList item that had been thought to be stuck in hover state. It was actually automatically focused by the line of code I removed. 

### Behaviors that should be QA'd:
 - Tab/Arrow Key functionality when switching focused items to make sure it works as desired/expected. 

### Github Issues closed by this PR:
 - Resolves #284 
